### PR TITLE
name conflict rendered GetSpellInfoVanilla(id) unusable

### DIFF
--- a/GetSpellInfoVanilla.lua
+++ b/GetSpellInfoVanilla.lua
@@ -100,7 +100,7 @@ function GetSpellInfoByIconAndName(Icon, Name)
 	return resultArray
 end
 
-function GPIV_Test()
+function GSIV_Test()
 	local buffTexture, buffApplications = UnitBuff("target", 1);
 	local tempTable = GetSpellInfoByIcon(buffTexture)
 	for k,v in pairs(tempTable) do


### PR DESCRIPTION
Using the function GetSpellInfoVanilla(id) caused LUA errors complaining that "GetSpellInfoVanilla" is a table value (i.e. the frame being created in line 2). Renaming the function should solve the issue. 
